### PR TITLE
Make it work in 0.18

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -12,7 +12,7 @@
         "BoxesAndBubbles.Engine"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.1 <= v < 5.0.0"
+        "elm-lang/core": "5.0.0 <= v < 5.1.1"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/examples/Example.elm
+++ b/examples/Example.elm
@@ -11,7 +11,7 @@ The scene is updated after each animation frame.
 
 -}
 
-import Html.App exposing (program)
+import Html exposing (program)
 import BoxesAndBubbles.Bodies exposing (..)
 import BoxesAndBubbles exposing (..)
 import BoxesAndBubbles.Math2D exposing (mul2)
@@ -102,7 +102,7 @@ update (Tick dt) bodies = uncurry step (constgravity dt) bodies
 {-| Run the animation started from the initial scene defined as `labeledBodies`.
 -}
 
-main : Program Never
+main : Program Never (Model String) Msg
 main = program { 
   init = (labeledBodies, Cmd.none)
   , update = (\msg bodies -> ( update msg bodies, Cmd.none ))

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -12,9 +12,9 @@
     ],
     "dependencies": {
         "elm-lang/animation-frame": "1.0.0 <= v < 2.0.0",
-        "elm-lang/html": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.1 <= v < 5.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "elm-lang/core": "5.0.0 <= v < 5.1.1",
         "evancz/elm-graphics": "1.0.0 <= v < 2.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
I made minimal changes until the example compiled and ran with elm-reactor using 0.18. Then I made it into this PR. I didn't presume to bump the package version.